### PR TITLE
Several fixes + some code formatting

### DIFF
--- a/sourcemod/scripting/TargetTalking.sp
+++ b/sourcemod/scripting/TargetTalking.sp
@@ -1,23 +1,25 @@
 #include <sourcemod>
 #include <sdktools>
+#include <cstrike>
 #include <voiceannounce_ex>
 #include <warden>
-#pragma newdecls required
 
-bool g_bIsClientSpeaking[MAXPLAYERS+1];
+#pragma newdecls required
+#pragma semicolon 1
+
+bool g_bIsClientSpeaking[MAXPLAYERS + 1];
 bool g_bIsWardenSpeaking;
 
-int g_WarningCounter[MAXPLAYERS+1];
+int g_WarningCounter[MAXPLAYERS + 1];
 
-ConVar g_cvEnabled;
 ConVar g_cvShowWarning;
 
-public Plugin myinfo =
+public Plugin myinfo = 
 {
-	name = "Target Talking",
-	author = "eXiLe",
-	description = "Plugin for admins to target players who are talking (Made for JailBreak)",
-	version = "1.2",
+	name = "Target Talking", 
+	author = "eXiLe", 
+	description = "Plugin for admins to target players who are talking (Made for JailBreak)", 
+	version = "1.2", 
 	url = "TBD"
 };
 
@@ -25,7 +27,6 @@ public void OnPluginStart()
 {
 	LoadTranslations("targettalking.phrases");
 	
-	g_cvEnabled = CreateConVar("targettalking_enabled", "1", "Sets whether the plugin is enabled");
 	g_cvShowWarning = CreateConVar("showwarning", "0", "After how many offenses to show hinttext warning to player (0 to disable)");
 	
 	AddMultiTargetFilter("@talking", DoTalking, "Talking", false);
@@ -41,11 +42,6 @@ public void OnPluginEnd()
 	RemoveMultiTargetFilter("@talkingct", DoTalkingct);
 	RemoveMultiTargetFilter("@talkingt", DoTalkingt);
 }
-public void onMapStart()
-{
-	if(!g_cvEnabled.BoolValue)
-		return;
-}
 
 public void OnClientPutInServer(int client)
 {
@@ -55,36 +51,38 @@ public void OnClientPutInServer(int client)
 
 public void OnClientSpeakingEx(int client)
 {
-    if (g_bIsClientSpeaking[client])
-    {
-        // This client was speaking already, we don't need to do things "as long as the player speaks" here so ignore this situation
-        return;
-    }
-
-    // The player has only just started speaking
-    g_bIsClientSpeaking[client] = true;
-
-    // Do your checks to see if the warden is speaking here
+	if (g_bIsClientSpeaking[client])
+	{
+		// This client was speaking already, we don't need to do things "as long as the player speaks" here so ignore this situation
+		return;
+	}
+	
+	// The player has only just started speaking
+	g_bIsClientSpeaking[client] = true;
+	
+	// Do your checks to see if the warden is speaking here
 	if (warden_iswarden(client))
 	{
 		g_bIsWardenSpeaking = true;
 		return;
-	}	
+	}
 	
-	if (g_cvShowWarning.IntValue != 0 && g_bIsWardenSpeaking && g_bIsClientSpeaking[client])
+	if (g_cvShowWarning.IntValue == 0 || !g_bIsWardenSpeaking)
 	{
-		g_WarningCounter[client]++;
-		if (g_WarningCounter[client] == g_cvShowWarning.IntValue)
-		{
-			PrintHintText(client, "%t", "Warning");
-		}
+		return;
+	}
+	
+	g_WarningCounter[client]++;
+	if (g_WarningCounter[client] >= g_cvShowWarning.IntValue)
+	{
+		PrintHintText(client, "%t", "Warning");
 	}
 }
 
 public void OnClientSpeakingEnd(int client)
 {
 	g_bIsClientSpeaking[client] = false;
-    if (warden_iswarden(client))
+	if (warden_iswarden(client))
 	{
 		g_bIsWardenSpeaking = false;
 	}
@@ -95,28 +93,25 @@ public bool DoTalking(const char[] pattern, Handle clients)
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
-		if (!warden_iswarden(i) && g_bIsClientSpeaking[i])
+		if (IsClientInGame(i) && !warden_iswarden(i) && g_bIsClientSpeaking[i])
 			PushArrayCell(clients, i);
 	}
 }
 
 public bool DoTalkingct(const char[] pattern, Handle clients)
 {
-	int client;
 	for (int i = 1; i <= MaxClients; i++)
 	{
-		if (!warden_iswarden(i) && g_bIsClientSpeaking[i] && GetClientTeam(client) == 3)
+		if (IsClientInGame(i) && !warden_iswarden(i) && g_bIsClientSpeaking[i] && GetClientTeam(i) == CS_TEAM_CT)
 			PushArrayCell(clients, i);
 	}
 }
 
 public bool DoTalkingt(const char[] pattern, Handle clients)
 {
-	int client;
 	for (int i = 1; i <= MaxClients; i++)
 	{
-		if (!warden_iswarden(i) && g_bIsClientSpeaking[i] && GetClientTeam(client) == 2)
+		if (IsClientInGame(i) && !warden_iswarden(i) && g_bIsClientSpeaking[i] && GetClientTeam(i) == CS_TEAM_T)
 			PushArrayCell(clients, i);
 	}
-}
-
+} 

--- a/sourcemod/scripting/TargetTalking.sp
+++ b/sourcemod/scripting/TargetTalking.sp
@@ -10,7 +10,7 @@
 bool g_bIsClientSpeaking[MAXPLAYERS + 1];
 bool g_bIsWardenSpeaking;
 
-int g_WarningCounter[MAXPLAYERS + 1];
+int g_iWarningCounter[MAXPLAYERS + 1];
 
 ConVar g_cvShowWarning;
 
@@ -27,26 +27,22 @@ public void OnPluginStart()
 {
 	LoadTranslations("targettalking.phrases");
 	
-	g_cvShowWarning = CreateConVar("showwarning", "0", "After how many offenses to show hinttext warning to player (0 to disable)");
-	
-	AddMultiTargetFilter("@talking", DoTalking, "Talking", false);
-	AddMultiTargetFilter("@talkingct", DoTalkingct, "Talking CT", false);
-	AddMultiTargetFilter("@talkingt", DoTalkingt, "Talking T", false);
-	
-	AutoExecConfig(true, "TargetTalking");
+	AddConVars();
+	AddTargetFilters();
+	HookEvents();
 }
 
 public void OnPluginEnd()
 {
-	RemoveMultiTargetFilter("@talking", DoTalking);
-	RemoveMultiTargetFilter("@talkingct", DoTalkingct);
-	RemoveMultiTargetFilter("@talkingt", DoTalkingt);
+	// I believe this gets done automatically when our plugin ends, but let's keep it in just to be sure
+	// Events definitely get unhooked automatically so that's not needed here for sure
+	RemoveTargetFilters();
 }
 
 public void OnClientPutInServer(int client)
 {
 	g_bIsClientSpeaking[client] = false;
-	g_WarningCounter[client] = 0;
+	g_iWarningCounter[client] = 0;
 }
 
 public void OnClientSpeakingEx(int client)
@@ -72,8 +68,8 @@ public void OnClientSpeakingEx(int client)
 		return;
 	}
 	
-	g_WarningCounter[client]++;
-	if (g_WarningCounter[client] >= g_cvShowWarning.IntValue)
+	g_iWarningCounter[client]++;
+	if (g_iWarningCounter[client] >= g_cvShowWarning.IntValue)
 	{
 		PrintHintText(client, "%t", "Warning");
 	}
@@ -88,30 +84,76 @@ public void OnClientSpeakingEnd(int client)
 	}
 }
 
+public void warden_OnWardenRemoved(int client)
+{
+	// Catch the scenarios in which the warden dies / get's fired before he stops talking
+	g_bIsWardenSpeaking = false;
+}
 
-public bool DoTalking(const char[] pattern, Handle clients)
+/* ------------------------------- EVENTS ------------------------------- */
+void HookEvents()
+{
+	HookEvent("round_start", Event_RoundStart);
+}
+
+public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcast)
+{
+	// Catch the scenario in which the new round starts while the previous round's warden is still talking
+	g_bIsWardenSpeaking = false;
+}
+
+/* --------------------------- TARGET FILTERS --------------------------- */
+void AddTargetFilters()
+{
+	AddMultiTargetFilter("@talking", TargetTalkingPlayers, "Talking", false);
+	AddMultiTargetFilter("@talkingct", TargetTalkingCTs, "Talking CT", false);
+	AddMultiTargetFilter("@talkingt", TargetTalkingTs, "Talking T", false);
+}
+
+void RemoveTargetFilters()
+{
+	RemoveMultiTargetFilter("@talking", TargetTalkingPlayers);
+	RemoveMultiTargetFilter("@talkingct", TargetTalkingCTs);
+	RemoveMultiTargetFilter("@talkingt", TargetTalkingTs);
+}
+
+public bool TargetTalkingPlayers(const char[] pattern, Handle clients)
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
 		if (IsClientInGame(i) && !warden_iswarden(i) && g_bIsClientSpeaking[i])
+		{
 			PushArrayCell(clients, i);
+		}
 	}
 }
 
-public bool DoTalkingct(const char[] pattern, Handle clients)
+public bool TargetTalkingCTs(const char[] pattern, Handle clients)
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
 		if (IsClientInGame(i) && !warden_iswarden(i) && g_bIsClientSpeaking[i] && GetClientTeam(i) == CS_TEAM_CT)
+		{
 			PushArrayCell(clients, i);
+		}
 	}
 }
 
-public bool DoTalkingt(const char[] pattern, Handle clients)
+public bool TargetTalkingTs(const char[] pattern, Handle clients)
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
 		if (IsClientInGame(i) && !warden_iswarden(i) && g_bIsClientSpeaking[i] && GetClientTeam(i) == CS_TEAM_T)
+		{
 			PushArrayCell(clients, i);
+		}
 	}
-} 
+}
+
+/* ------------------------------ CONVARS ------------------------------ */
+void AddConVars()
+{
+	g_cvShowWarning = CreateConVar("showwarning", "0", "After how many offenses to show hinttext warning to player (0 to disable)");
+	
+	AutoExecConfig(true, "TargetTalking");
+}


### PR DESCRIPTION
Changes:

* The target filters will now work correctly (they were missing an IsClientInGame check + I removed the "client" variable since there was no way of using that properly there (unless you rename the "i" variable to client)
* The plugin will now correctly notice the warden is no longer talking when a new round starts or when the previous one gets removed (due to disconnect / death / getting fired by staff)
* Removed a double check for `g_bIsClientSpeaking[client]`
* Removed the OnMapStart function since nothing was really happening in there (it checked if the plugin was enabled, but didn't disable anything when the convar was set as disabled)
* Few more things like I reformatted the code (now has the same formatting as I use in my own plugins)